### PR TITLE
Add Bearer token authentication for CLI tools

### DIFF
--- a/kerneltest/app.py
+++ b/kerneltest/app.py
@@ -11,6 +11,7 @@ from functools import wraps
 import flask
 import flask_wtf
 import munch
+import requests
 import six
 import wtforms as wtf
 from flask_oidc import OpenIDConnect
@@ -72,10 +73,60 @@ APP.wsgi_app = ProxyFix(APP.wsgi_app, x_proto=1, x_host=1)
 SESSION = dbtools.create_session(APP.config["DB_URL"])
 
 
+def validate_bearer_token(token):
+    """Validate a Bearer token against the OIDC provider userinfo endpoint.
+
+    This enables CLI tools using openidc_client to authenticate via
+    Authorization: Bearer headers, rather than requiring browser-based
+    cookie authentication.
+
+    Args:
+        token: The Bearer token from the Authorization header
+
+    Returns:
+        dict with user info if valid, None if invalid/expired
+    """
+    userinfo_url = OIDC.client_secrets["userinfo_uri"]
+    try:
+        resp = requests.get(
+            userinfo_url,
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=10
+        )
+        if resp.status_code == 200:
+            try:
+                return resp.json()
+            except ValueError:
+                APP.logger.warning("Invalid JSON from userinfo endpoint")
+                return None
+    except requests.RequestException as e:
+        APP.logger.warning(f"Bearer token validation failed: {e}")
+    return None
+
+
 @APP.before_request
 def set_session():  # pragma: no-cover
     """Set the flask session as permanent."""
     flask.session.permanent = True
+
+    # Check for Bearer token authentication (used by CLI tools like kernel-tests)
+    auth_header = flask.request.headers.get("Authorization", "")
+    if auth_header.startswith("Bearer ") and not OIDC.user_loggedin:
+        token = auth_header.removeprefix("Bearer ")
+        user_info = validate_bearer_token(token)
+        if user_info:
+            flask.g.fas_user = munch.Munch(
+                {
+                    "username": user_info.get(
+                        "nickname", user_info.get("preferred_username")
+                    ),
+                    "email": user_info.get("email", ""),
+                    "timezone": user_info.get("zoneinfo"),
+                    "groups": user_info.get("groups", []),
+                    "cla_done": "signed_fpca" in (user_info.get("groups") or []),
+                }
+            )
+            return  # Bearer auth successful, skip cookie check
 
     if OIDC.user_loggedin:
         if not hasattr(flask.session, "fas_user") or not flask.session.fas_user:

--- a/poetry.lock
+++ b/poetry.lock
@@ -3091,4 +3091,4 @@ deploy = ["gunicorn"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9.0"
-content-hash = "9a4b43121a444d983ae34817036efb8bccabe04dbf57a651657f09c91ac48704"
+content-hash = "f8cbbd08366d46658ccd9e0a703910d8f866abe893639e8f0983c1a8da536fda"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ gunicorn = ">=21.0.0"
 kerneltest-messages = "^1.0.0"
 backoff = "^2.2.1"
 fedora-messaging = "^3.5.0"
+requests = "^2.32.5"
 
 [tool.poetry.group.dev.dependencies]
 pytest = ">=7.1.0"

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -15,6 +15,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), ".."
 
 from pathlib import Path
 
+import responses
 from fedora_messaging import testing as fml_testing
 from kerneltest_messages import ReleaseEditV1, ReleaseNewV1, UploadNewV1
 
@@ -181,6 +182,35 @@ class KerneltestTests(Modeltests):
         data = json.loads(output.data)
         exp = {"error": "Invalid input file"}
         self.assertEqual(data, exp)
+
+    def test_upload_results_bearer_token(self):
+        """Test anonymous upload endpoint with Bearer token authentication."""
+        folder = Path(__file__).parent
+        user_info = {
+            "nickname": "testuser",
+            "email": "testuser@example.com",
+            "zoneinfo": None,
+            "groups": ["signed_fpca"],
+        }
+        expected_message = UploadNewV1(message_result(tester="testuser"))
+
+        with (folder / "1.log").open("rb") as test_result:
+            data = {
+                "test_result": test_result,
+                "username": "anonymous",
+            }
+            with responses.RequestsMock() as rsps:
+                rsps.get(app.OIDC.client_secrets["userinfo_uri"], json=user_info)
+                with fml_testing.mock_sends(expected_message):
+                    output = self.app.post(
+                        "/upload/anonymous",
+                        data=data,
+                        headers={"Authorization": "Bearer valid-token"},
+                    )
+
+        self.assertEqual(output.status_code, 200)
+        data = json.loads(output.data)
+        self.assertEqual(data, {"message": "Upload successful!"})
 
     def test_upload_results_autotest(self):
         """Test the app.upload_results function for the autotest user."""


### PR DESCRIPTION
The kernel-tests CLI (fedora_submit.py) uses openidc_client to authenticate via `Authorization: Bearer` headers. However, the server only checked for browser-based cookie authentication via OIDC.user_loggedin.

This caused CLI submissions to silently fall back to anonymous uploads, even when the user had successfully authenticated. As a result:
- No fedora-messaging events were published for these uploads
- Upload attribution was lost

This fix adds Bearer token validation by checking the Authorization header and validating tokens against the Fedora OIDC userinfo endpoint before falling back to cookie-based authentication.

Fixes: https://github.com/fedora-infra/kerneltest/issues/147

Relevant links
1. [OAuth 2.0 Bearer Token spec](https://www.rfc-editor.org/rfc/rfc6750)
This defines: `Authorization: Bearer <token>`
2. [OpenID Connect Core spec](https://openid.net/specs/openid-connect-core-1_0.html)
Useful sections:
    - [UserInfo endpoint](https://openid.net/specs/openid-connect-core-1_0.html#UserInfo)
    - [Bearer token use with UserInfo](https://openid.net/specs/openid-connect-core-1_0.html#UserInfoRequest)
3. Fedora OIDC discovery https://id.fedoraproject.org/openidc/.well-known/openid-configuration
Shows Fedora’s actual endpoints, including: `"userinfo_endpoint": "https://id.fedoraproject.org/openidc/UserInfo"`